### PR TITLE
Fix out of range

### DIFF
--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -298,9 +298,11 @@ void PointCloudToLaserScanNode::cloudCallback(PointCloud2::ConstSharedPtr cloud_
 
     // overwrite range at laserscan ray if new range is smaller
     int index = (angle - scan_msg->angle_min) / scan_msg->angle_increment;
-    if (range < scan_msg->ranges[index]) {
-      scan_msg->ranges[index] = range;
-      v_pointcloud_index.at(index) = pointcloud_index;
+    if (index < scan_msg->ranges.size()) {
+      if (range < scan_msg->ranges[index]) {
+        scan_msg->ranges[index] = range;
+        v_pointcloud_index.at(index) = pointcloud_index;
+      }
     }
   }
 


### PR DESCRIPTION
`std::ceil((scan_msg->angle_max - scan_msg->angle_min) / scan_msg->angle_increment) == (scan_msg->angle_max - scan_msg->angle_min) / scan_msg->angle_increment`の場合、
`int index = (angle - scan_msg->angle_min) / scan_msg->angle_increment;`で`angle == scan_msg->angle_max`のとき
indexにrangesのsizeが入ってしまうので修正。
ex) https://github.com/tier4/autoware.iv/blob/1c1b047c50b781fecd3d6873cc002544b644934d/sensing/preprocessor/pointcloud/laserscan_to_occupancy_grid_map/launch/laserscan_to_occupancy_grid_map.launch.py#L62-L64 のとき、index=1440が入ってしまう。
```
[component_container-17] terminate called after throwing an instance of 'std::out_of_range'
[component_container-17]   what():  vector::_M_range_check: __n (which is 1440) >= this->size() (which is 1440)
[ERROR] [component_container-17]: process has died [pid 2038193, exit code -6, cmd '/opt/ros/galactic/lib/rclcpp_components/component_container --ros-args -r __node:=occupancy_grid_map_container -r __ns:=/ --params-file /tmp/launch_params_kvrfu_tn'].
```