### PR TITLE
fix(log-messages): lower log level for a log message from info to debug

### DIFF
--- a/src/pointcloud_to_laserscan_node.cpp
+++ b/src/pointcloud_to_laserscan_node.cpp
@@ -189,7 +189,7 @@ void PointCloudToLaserScanNode::subscriptionListenerThreadLoop()
       laserscan_pub_->get_intra_process_subscription_count();
     if (subscription_count > 0) {
       if (!sub_.getSubscriber()) {
-        RCLCPP_INFO(
+        RCLCPP_DEBUG(
           this->get_logger(),
           "Got a subscriber to laserscan, starting pointcloud subscriber");
         rclcpp::SensorDataQoS qos;


### PR DESCRIPTION
## Description

This PR is one of group of PRs that aim to fix Autoware logging system to achieve the goal of reducing excessive error and warning logs on Autoware launch.

Fixes https://github.com/autowarefoundation/autoware.universe/issues/5539

## Related links
More details in the [issue](https://github.com/autowarefoundation/autoware.universe/issues/5539).

### Relevant PRS
- [autoware.universe](https://github.com/autowarefoundation/autoware.universe/pull/5971)
- [autoware_launch](https://github.com/autowarefoundation/autoware_launch/pull/760)
- [autoware_common](https://github.com/autowarefoundation/autoware_common/pull/224)

## Tests performed

- Planning Simulation
  - Run [Autoware planning simulator](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/) and you can see no more excessive and recurring error, warning, and info message when the system running as expected
- Rosbag Replay Simulation
  - To be addressed in another PR
- AWSIM
  - To be addressed in another PR - extended goal

## Notes for reviewers
Take into consideration relevant PRs.
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
N.A
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
- Improved console output => better developer experience specially for debugging and catching actual problems.
- Some recurrent info messages are lowered to debug level. So the developer would need to set the logger level of that specific node to see the debug message.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
